### PR TITLE
Modify `vpuh` function to take `&str` and return enum.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libpasta"
-version = "0.0.6"
+version = "0.1.0-rc0"
 authors = ["Sam Scott <me@samjs.co.uk>"]
 categories = ["authentication", "cryptography"]
 description = "All-inclusive password hashing library"
@@ -18,7 +18,7 @@ fastpbkdf2 = "0.1"
 itertools = "0.7"
 lazy_static = "1.0"
 log = "0.4"
-num-traits = "0.1"
+num-traits = "0.2"
 ring-pwhash = ">= 0.11, < 0.13"
 rpassword = "2.0"
 rust-crypto = "0.2"
@@ -33,7 +33,7 @@ default-features = false
 features = []
 
 [dev-dependencies]
-env_logger = "0.4"
+env_logger = "0.5"
 time = "0.1.36"
 
 [features]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.0.6
+VERSION = 0.1.0-rc0
 
 all: libpasta.so libpasta.a
 

--- a/libpasta-capi/Cargo.toml
+++ b/libpasta-capi/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "pasta"
-version = "0.0.6"
+version = "0.1.0-rc0"
 authors = ["Sam Scott <sam.scott89@gmail.com>"]
 build = "build.rs"
 
 
 [dependencies]
 libc = "0.2"
-libpasta = { version = "0.0.6", path = ".." }
+libpasta = { version = "0.1.0-rc0", path = ".." }
 rpassword = "2.0"
 
 [build-dependencies]
-cbindgen = "0.3"
+cbindgen = "0.4"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/libpasta-capi/ctest/compile.sh
+++ b/libpasta-capi/ctest/compile.sh
@@ -2,5 +2,5 @@
 
 set -ex
 
-cargo build --release --manifest-path ../Cargo.toml
-g++ -DDEBUG -std=c++11 -g -o test test.cpp -Wall -I../include -L../target/release -lpasta
+cargo build --release  --manifest-path ../Cargo.toml
+g++ -DDEBUG -std=c++11 -ggdb -o test test.cpp -Wall -I../include  -L../target/release/ -lpasta

--- a/libpasta-capi/ctest/test.cpp
+++ b/libpasta-capi/ctest/test.cpp
@@ -21,7 +21,7 @@ void test_migrate() {
         case HashUpdateFfi::Tag::Failed: assert (false && "Problem migrating password");
     }
     assert (strcmp(old_hash, hash) != 0);
-    // printf("New hash: %s\n", hash);
+    printf("New hash: %s\n", hash);
     free_string(hash);
 
     hash = (char *)"$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa";

--- a/libpasta-capi/ctest/test.cpp
+++ b/libpasta-capi/ctest/test.cpp
@@ -19,17 +19,19 @@ void test_migrate() {
 
     hash = (char *)"$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa";
     char *newhash;
-    bool res = verify_password_update_hash_in_place(hash, "my password", &newhash);
-    assert (res);
-    // printf("New hash: %s\n", newhash);
+    HashUpdateFfi *res = verify_password_update_hash(hash, "my password");
+    switch(res->tag) {
+        case HashUpdateFfi::Tag::Updated: newhash = res->updated._0;
+        case HashUpdateFfi::Tag::Verified: printf("Password verified\n"); break;
+        case HashUpdateFfi::Tag::Failed: assert (false && "Password failed");
+    }
+    printf("New hash: %s\n", newhash);
     assert (strcmp(newhash, hash) != 0);
     assert (verify_password(newhash, "my password"));
     // free_string(hash) // dont need to free this since it's static
     free_string(newhash);
 
-    assert (!verify_password_update_hash_in_place(hash, "not my password", &newhash));
-    // printf("New hash: %s\n", newhash);
-    free_string(newhash);
+    assert (verify_password_update_hash(hash, "not my password")->tag == HashUpdateFfi::Tag::Failed);
 }
 
 void test_config() {

--- a/libpasta-capi/ctest/test.cpp
+++ b/libpasta-capi/ctest/test.cpp
@@ -12,17 +12,24 @@ void test_hash_and_verify() {
 }
 
 void test_migrate() {
-    char *hash = (char *)"$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa";
-    hash = migrate_hash(hash);
+    char *old_hash = (char *)"$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa";
+    char *hash;
+    HashUpdateFfi *res = migrate_hash(old_hash);
+    switch(res->tag) {
+        case HashUpdateFfi::Tag::Updated: hash = res->updated._0; break;
+        case HashUpdateFfi::Tag::Ok: assert (false && "Expected a password migration");
+        case HashUpdateFfi::Tag::Failed: assert (false && "Problem migrating password");
+    }
+    assert (strcmp(old_hash, hash) != 0);
     // printf("New hash: %s\n", hash);
     free_string(hash);
 
     hash = (char *)"$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa";
     char *newhash;
-    HashUpdateFfi *res = verify_password_update_hash(hash, "my password");
+    res = verify_password_update_hash(hash, "my password");
     switch(res->tag) {
         case HashUpdateFfi::Tag::Updated: newhash = res->updated._0;
-        case HashUpdateFfi::Tag::Verified: printf("Password verified\n"); break;
+        case HashUpdateFfi::Tag::Ok: printf("Password verified\n"); break;
         case HashUpdateFfi::Tag::Failed: assert (false && "Password failed");
     }
     printf("New hash: %s\n", newhash);

--- a/libpasta-capi/include/pasta-bindings.h
+++ b/libpasta-capi/include/pasta-bindings.h
@@ -20,7 +20,7 @@ struct Primitive;
 struct HashUpdateFfi {
   enum class Tag {
     Updated,
-    Verified,
+    Ok,
     Failed,
   };
 
@@ -38,7 +38,7 @@ extern "C" {
 
 char *config_hash_password(const Config *config, const char *password);
 
-char *config_migrate_hash(const Config *config, const char *hash);
+HashUpdateFfi *config_migrate_hash(const Config *config, const char *hash);
 
 bool config_verify_password(const Config *config, const char *hash, const char *password);
 
@@ -64,7 +64,7 @@ void free_string(char *s);
 
 char *hash_password(const char *password);
 
-char *migrate_hash(const char *hash);
+HashUpdateFfi *migrate_hash(const char *hash);
 
 Primitive *new_argon2i(unsigned int passes, unsigned int lanes, unsigned int kib);
 

--- a/libpasta-capi/include/pasta-bindings.h
+++ b/libpasta-capi/include/pasta-bindings.h
@@ -17,6 +17,23 @@ struct Config;
 // arbitrary parameter sets is essential.
 struct Primitive;
 
+struct HashUpdateFfi {
+  enum class Tag {
+    Updated,
+    Verified,
+    Failed,
+  };
+
+  struct Updated_Body {
+    char *_0;
+  };
+
+  Tag tag;
+  union {
+    Updated_Body updated;
+  };
+};
+
 extern "C" {
 
 char *config_hash_password(const Config *config, const char *password);
@@ -25,10 +42,9 @@ char *config_migrate_hash(const Config *config, const char *hash);
 
 bool config_verify_password(const Config *config, const char *hash, const char *password);
 
-bool config_verify_password_update_hash(const Config *config,
-                                        const char *hash,
-                                        const char *password,
-                                        char **new_hash);
+HashUpdateFfi *config_verify_password_update_hash(const Config *config,
+                                                  const char *hash,
+                                                  const char *password);
 
 Config *config_with_primitive(const Primitive *prim);
 
@@ -60,6 +76,6 @@ char *read_password(const char *prompt);
 
 bool verify_password(const char *hash, const char *password);
 
-bool verify_password_update_hash_in_place(const char *hash, const char *password, char **new_hash);
+HashUpdateFfi *verify_password_update_hash(const char *hash, const char *password);
 
 } // extern "C"

--- a/libpasta-capi/src/lib.rs
+++ b/libpasta-capi/src/lib.rs
@@ -3,6 +3,8 @@ extern crate libpasta;
 extern crate rpassword;
 
 use libpasta::HashUpdate;
+use libpasta::primitives::*;
+use libpasta::config::Config;
 
 use libc::{c_char, c_uchar, c_uint};
 use rpassword::prompt_password_stdout;
@@ -113,10 +115,6 @@ pub extern "C" fn config_verify_password_update_hash(config: *const Config, hash
     box_ptr!(config.verify_password_update_hash(hash, password).into())
 }
 
-// use libpasta::primitives::Primitive;
-use libpasta::primitives::*;
-use libpasta::config::Config;
-
 #[no_mangle]
 pub extern "C" fn migrate_hash(hash: *const c_char) -> *mut HashUpdateFfi {
     let hash = unsafe { ffi_string!(hash).to_owned() };
@@ -193,7 +191,7 @@ pub extern "C" fn free_Config(config: *mut Config) {
 
 #[cfg(test)]
 mod test {
-    use std::ffi::{CStr, CString};
+    use std::ffi::CString;
 
     #[test]
     fn test_migrate() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -327,6 +327,11 @@ mod test {
     fn use_config() {
         let config = Config::with_primitive(primitives::Argon2::default());
         let hash = config.hash_password("hunter2".into());
+        assert!(config.verify_password(&hash, "hunter2".into()));
+
+        let mut config = Config::default();
+        config.set_primitive(primitives::Bcrypt::default());
+        let hash = config.hash_password("hunter2".into());
         assert!(verify_password(&hash, "hunter2".into()));
     }
 
@@ -350,7 +355,8 @@ mod test {
     fn alternate_key_source() {
         let mut config = Config::default();
         config.set_key_source(&STATIC_SOURCE);
-        assert_eq!(config.get_key("dummy"), Some(b"ThisIsAStaticKey".to_vec()));
+        let id = config.add_key(&[]);
+        assert_eq!(config.get_key(&id), Some(b"ThisIsAStaticKey".to_vec()));
         let hmac = primitives::Hmac::with_key_id(&ring::digest::SHA256, "dummy");
         config.set_keyed_hash(hmac);
         let hash = config.hash_password("hunter2");

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,7 +201,7 @@ impl Config {
     pub fn verify_password_update_hash_safe(&self, hash: &str, password: &str) -> Result<HashUpdate> {
         let pwd_hash: Output = serde_mcf::from_str(hash)?;
         if pwd_hash.verify(password) {
-            if pwd_hash.alg != *DEFAULT_ALG {
+            if pwd_hash.alg != self.algorithm {
                 let new_hash = serde_mcf::to_string(&self.algorithm.hash(password))?;
                 Ok(HashUpdate::Verified(Some(new_hash)))
             } else {

--- a/src/hashing/mod.rs
+++ b/src/hashing/mod.rs
@@ -6,6 +6,7 @@
 //! recursive structure, containing either a single `Primitive`, or a
 //! `Primitive` and a further layer of `Algorithm`. This is the hashing onion.
 
+use std::cmp::Ordering;
 use std::default::Default;
 
 use config;
@@ -100,7 +101,15 @@ impl Algorithm {
 
         match *self {
             Algorithm::Single(ref a2) |
-            Algorithm::Nested { outer: ref a2, .. } => a2.ge(default),
+            // Note: here we only decide to migrate if default is not <= a2
+            // This includes the case that they are incomparable
+            Algorithm::Nested { outer: ref a2, .. } => {
+                match a2.partial_cmp(default) {
+                    Some(Ordering::Greater) | Some(Ordering::Equal) => false,
+                    _ => true,
+                }
+            }
+
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,9 +439,14 @@ mod api_tests {
     fn migrate_hash_ok() {
         let mut hash = "$2a$10$175ikf/E6E.73e83.fJRbODnYWBwmfS0ENdzUBZbedUNGO.99wJfa".to_owned();
         if let Some(new_hash) = migrate_hash(&hash) {
+            println!("{:?}", new_hash);
+            assert!(new_hash != hash);
             hash = new_hash;
+        } else {
+            assert!(false, "expected to migrate the hash");
         }
         println!("{:?}", hash);
+        assert!(migrate_hash(&hash).is_none());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,16 +222,29 @@ pub fn verify_password_safe(hash: &str, password: &str) -> Result<bool> {
     Ok(pwd_hash.verify(password))
 }
 
+/// On migrating a hash with the password entered, we reach three possible
+/// states:
+///   - Password verified, and the hash was migrated
+///   - Password verified, but the hash did not need to be migrated
+///   - Incorrect password (or other verification failure)
+pub enum HashUpdate {
+    /// Password verification succeeded, with new string if migration was
+    /// performed
+    Verified(Option<String>),
+    /// Password verification failed
+    Failed,
+}
+
 /// Verifies a supplied password against a previously computed password hash,
 /// and performs an in-place update of the hash value if the password verifies.
 /// Hence this needs to take a mutable `String` reference.
-pub fn verify_password_update_hash(hash: &mut String, password: &str) -> bool {
+pub fn verify_password_update_hash(hash: &str, password: &str) -> HashUpdate {
     config::DEFAULT_CONFIG.verify_password_update_hash(hash, password)
 }
 
 /// Same as `verify_password_update_hash`, but returns `Result` to allow error handling.
 #[doc(hidden)]
-pub fn verify_password_update_hash_safe(hash: &mut String, password: &str) -> Result<bool> {
+pub fn verify_password_update_hash_safe(hash: &str, password: &str) -> Result<HashUpdate> {
     config::DEFAULT_CONFIG.verify_password_update_hash_safe(hash, password)
 
 }
@@ -245,13 +258,13 @@ pub fn verify_password_update_hash_safe(hash: &mut String, password: &str) -> Re
 ///
 /// If the password is also available, the `verify_password_update_hash` should
 /// instead be used.
-pub fn migrate_hash(hash: &mut String) {
+pub fn migrate_hash(hash: &str) -> Option<String> {
     config::DEFAULT_CONFIG.migrate_hash(hash)
 }
 
 /// Same as `migrate_hash` but returns `Result` to allow error handling.
 #[doc(hidden)]
-pub fn migrate_hash_safe(hash: &mut String) -> Result<()> {
+pub fn migrate_hash_safe(hash: &str) -> Result<Option<String>> {
     config::DEFAULT_CONFIG.migrate_hash_safe(hash)
 
 }
@@ -368,21 +381,26 @@ mod api_tests {
         let params = Algorithm::Single(Bcrypt::default());
         let mut hash = serde_mcf::to_string(&params.hash(&password)).unwrap();
         println!("Original: {:?}", hash);
-        migrate_hash(&mut hash);
+        if let Some(new_hash) = migrate_hash(&hash) {
+            hash = new_hash;
+        }
         println!("Migrated: {:?}", hash);
 
         let password = "hunter2";
         assert!(verify_password(&hash, password));
 
         let password = "hunter2";
-        assert!(verify_password_update_hash(&mut hash, password));
-        println!("Updated: {:?}", hash);
-
-
-        let password = "hunter2";
-        let mut pwd_hash: Output = serde_mcf::from_str(&hash).unwrap();
-        pwd_hash.alg = Algorithm::default();
-        assert!(pwd_hash.verify(&password));
+        if let HashUpdate::Verified(Some(new_hash)) = verify_password_update_hash(&hash, password) {
+            let password = "hunter2";
+            let mut pwd_hash: Output = serde_mcf::from_str(&new_hash).unwrap();
+            // Note, this is not the intended way to use these structs, but just
+            // a sanity check to make sure the new algorithm is _actually_ the
+            // supposed default.
+            pwd_hash.alg = Algorithm::default();
+            assert!(pwd_hash.verify(&password));
+        } else {
+            assert!(false, "hash was not verified/migrated");
+        }
     }
 
     #[test]
@@ -420,7 +438,10 @@ mod api_tests {
     #[test]
     fn migrate_hash_ok() {
         let mut hash = "$2a$10$175ikf/E6E.73e83.fJRbODnYWBwmfS0ENdzUBZbedUNGO.99wJfa".to_owned();
-        migrate_hash(&mut hash);
+        if let Some(new_hash) = migrate_hash(&hash) {
+            hash = new_hash;
+        }
+        println!("{:?}", hash);
     }
 
     #[test]

--- a/src/sod.rs
+++ b/src/sod.rs
@@ -11,10 +11,11 @@
 /// Many thanks to [panicbit](https://github.com/panicbit) for helping to
 /// get the `Deref` implementation working to make all the magic happen.
 
+use std::cmp::Ordering;
 use std::ops::Deref;
 use std::sync::Arc;
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug)]
 /// Enum to hold either static references or reference-counted owned objects.
 /// Implements `Deref` to `T` for ease of use.
 /// Since internal data is either a static reference, or an `Arc`, cloning
@@ -42,5 +43,17 @@ impl<T: ?Sized> Clone for Sod<T> {
             Sod::Static(t) => Sod::Static(t),
             Sod::Dynamic(ref t) => Sod::Dynamic(Arc::clone(t)),
         }
+    }
+}
+
+impl<T: PartialEq + ?Sized> PartialEq<Sod<T>> for Sod<T> {
+    fn eq(&self, other: &Sod<T>) -> bool {
+        self.deref().eq(other.deref())
+    }
+}
+
+impl<T: PartialOrd + ?Sized> PartialOrd<Sod<T>> for Sod<T> {
+    fn partial_cmp(&self, other: &Sod<T>) -> Option<Ordering> {
+        self.deref().partial_cmp(other.deref())
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -33,5 +33,5 @@ pub fn get_test_path(filename: &str) -> PathBuf {
 }
 
 pub fn init_test() {
-    self::env_logger::init().unwrap();
+    self::env_logger::init();
 }


### PR DESCRIPTION
Options are either Verified/Failed, and Verified has an optional
String return value.

In the C-API code, we expand this to a enum of 3 values.

Fixes #4 