### PR TITLE
make fastpbkdf2 dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ argon2rs = "0.2"
 cargon = "0.0.1"
 data-encoding = "2.0.0"
 error-chain = "0.11.0"
-fastpbkdf2 = "0.1"
+fastpbkdf2 = { version = "0.1", optional = true }
 itertools = "0.7"
 lazy_static = "1.0"
 log = "0.4"

--- a/src/primitives/pbkdf2.rs
+++ b/src/primitives/pbkdf2.rs
@@ -1,8 +1,12 @@
-/// Native Rust implementation of scrypt.
+#[cfg(feature = "fastpbkdf2")]
 pub use self::fastpbkdf2::Pbkdf2;
+
+#[cfg(not(feature = "fastpbkdf2"))]
+pub use self::ring_pbkdf2::Pbkdf2 as Pbkdf2;
+
 pub use self::ring_pbkdf2::Pbkdf2 as RingPbkdf2;
 
-/// Native Rust implementation of scrypt.
+/// Native Rust implementation of PBKDF2.
 mod ring_pbkdf2 {
     use primitives::{Primitive, PrimitiveImpl};
     use sod::Sod;
@@ -84,7 +88,8 @@ mod ring_pbkdf2 {
 }
 
 
-/// Native Rust implementation of scrypt.
+/// C implementation of PBKDF2.
+#[cfg(feature = "fastpbkdf2")]
 mod fastpbkdf2 {
     extern crate fastpbkdf2;
     use self::fastpbkdf2::*;


### PR DESCRIPTION
Unlike openssl-sys, fastpbkdf2 currently doesn't compile out of the box
on macOS, even after "brew install openssl@1.1". You have to build with
a couple environmental variables specified:
LIBRARY_PATH=/usr/local/opt/openssl@1.1/lib
CFLAGS=-I/usr/local/opt/openssl@1.1/include

I want my software to be super easy to install, and libpasta supports
the same functionality from ring, so use that by default.

(I could duplicate openssl-sys's build.rs logic into fastpbkdf2, or some
trimmed version of it, but this seems simpler and more foolproof.)