### PR TITLE
Test OSX build. Remove fastpbkdf2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: cargo
 dist: trusty
 os: 
   - linux
-  # - osx
+  - osx
 
 # Run builds for all the supported trains
 rust:
@@ -12,19 +12,19 @@ rust:
   - beta
   - nightly
 
-sudo: true
 
-env:
-  global:
-  - RUSTFLAGS="-C link-dead-code"
-
-before_install:
-  - sudo apt-get update
-
-addons:
-  apt:
-    packages:
-      - libssl-dev
+matrix:
+  include:
+    - rust: stable
+      os: linux
+      sudo: true
+      env: SKIPTEST=true RUSTFLAGS="-C link-dead-code"
+      before_install:
+        - sudo apt-get update
+      addons:
+        apt:
+          packages:
+            - libssl-dev
 
 # Add clippy
 before_script:
@@ -36,18 +36,21 @@ before_script:
 
 # The main build
 script:
-  - cargo build
-  - cargo test
+  - |
+      if [[ -z $SKIPTEST ]]; then
+        cargo build
+        cargo test
+        make test
+      fi
   - |
       if [[ "$TRAVIS_RUST_VERSION" == "nightly" && $CLIPPY ]]; then
         cargo clippy
       fi
-  - make test
 
 # Coverage report
 after_success:
   - |
-      if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+      if [[ "$TRAVIS_RUST_VERSION" == "stable" && "$TRAVIS_OS_NAME" = linux ]]; then
         bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
         # Uncomment the following line for coveralls.io
         # cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libpasta"
-version = "0.1.0-rc0"
+version = "0.1.0-rc1"
 authors = ["Sam Scott <me@samjs.co.uk>"]
 categories = ["authentication", "cryptography"]
 description = "All-inclusive password hashing library"
@@ -11,10 +11,8 @@ repository = "https://github.com/libpasta/libpasta"
 
 [dependencies]
 argon2rs = "0.2"
-cargon = "0.0.1"
 data-encoding = "2.0.0"
 error-chain = "0.11.0"
-fastpbkdf2 = "0.1"
 itertools = "0.7"
 lazy_static = "1.0"
 log = "0.4"
@@ -23,7 +21,7 @@ ring-pwhash = ">= 0.11, < 0.13"
 rpassword = "2.0"
 rust-crypto = "0.2"
 serde = "1.0.2"
-serde_derive = "1.0.4"
+serde_derive = "1.0"
 serde_mcf = "0.1.3"
 serde_yaml = "0.7"
 
@@ -33,6 +31,7 @@ default-features = false
 features = []
 
 [dev-dependencies]
+cargon = "0.0.1"
 env_logger = "0.5"
 time = "0.1.36"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.1.0-rc0
+VERSION = 0.1.0-rc1
 
 all: libpasta.so libpasta.a
 

--- a/libpasta-capi/Cargo.toml
+++ b/libpasta-capi/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "pasta"
-version = "0.1.0-rc0"
+version = "0.1.0-rc1"
 authors = ["Sam Scott <sam.scott89@gmail.com>"]
 build = "build.rs"
 
 
 [dependencies]
 libc = "0.2"
-libpasta = { version = "0.1.0-rc0", path = ".." }
+libpasta = { version = "0.1.0-rc1", path = ".." }
 rpassword = "2.0"
 
 [build-dependencies]
-cbindgen = "0.4"
+cbindgen = "0.5"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/libpasta-capi/ctest/compile.sh
+++ b/libpasta-capi/ctest/compile.sh
@@ -3,4 +3,4 @@
 set -ex
 
 cargo build --release  --manifest-path ../Cargo.toml
-g++ -DDEBUG -std=c++11 -ggdb -o test test.cpp -Wall -I../include  -L../target/release/ -lpasta
+${CC:="gcc"} -DDEBUG -std=c++11 -ggdb -o test test.cpp -Wall -I../include  -L../target/release/ -lpasta

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -15,11 +15,11 @@ macro_rules! benches {
 
             #[bench]
             fn short(b: &mut Bencher) {
-                let password = "hunter2*********".to_owned();
+                let password = "hunter2*********";
                 let alg = Algorithm::Single(<$params>::default().into());
                 println!("Bench params: {:?}", alg);
                 b.iter(|| {
-                    alg.hash(password.clone().into())
+                    alg.hash(password)
                 })
             }
 
@@ -30,7 +30,7 @@ macro_rules! benches {
                 let alg = Algorithm::Single(<$params>::default().into());
                 println!("Bench params: {:?}", alg);
                 b.iter(|| {
-                    alg.hash(password.clone().into())
+                    alg.hash(&password)
                 })
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,6 @@
 //! `libpasta` attempts to support some legacy formats. For example, the `bcrypt`
 //! format `$2y$...`.
 
-#![cfg_attr(all(feature="bench", test), feature(test))]
-
-
 #![allow(unknown_lints)]
 #![deny(clippy_pedantic)]
 #![allow(
@@ -100,6 +97,8 @@
     warnings,
     while_true,
 )]
+// Necessary for having benchmarks defined inline.
+#![cfg_attr(all(feature="bench", test), feature(test))]
 #![cfg_attr(all(feature="bench", test), allow(unstable_features))]
 
 extern crate data_encoding;
@@ -339,9 +338,11 @@ mod api_tests {
     fn nested_hash() {
         let password = "hunter2";
 
+        let fast_prim = Bcrypt::new(5);
+
         let params = Algorithm::Nested {
-            inner: Box::new(Algorithm::default()),
-            outer: DEFAULT_PRIM.clone(),
+            inner: Box::new(Algorithm::Single(fast_prim.clone())),
+            outer: fast_prim.clone(),
         };
         let hash = params.hash(&password);
 
@@ -379,7 +380,7 @@ mod api_tests {
     fn migrate() {
         let password = "hunter2";
 
-        let params = Algorithm::Single(Bcrypt::default());
+        let params = Algorithm::Single(Bcrypt::new(5));
         let mut hash = serde_mcf::to_string(&params.hash(&password)).unwrap();
         println!("Original: {:?}", hash);
         if let Some(new_hash) = migrate_hash(&hash) {

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -39,7 +39,7 @@ pub use self::hmac::Hmac;
 /// Implementations are from both `ring` and the C `fastpbkdf2` implementations.
 /// The latter is currently in use.
 mod pbkdf2;
-pub use self::pbkdf2::{Pbkdf2, RingPbkdf2};
+pub use self::pbkdf2::Pbkdf2;
 
 /// `Scrypt` implementations.
 ///

--- a/src/primitives/pbkdf2.rs
+++ b/src/primitives/pbkdf2.rs
@@ -1,8 +1,6 @@
-/// Native Rust implementation of scrypt.
-pub use self::fastpbkdf2::Pbkdf2;
-pub use self::ring_pbkdf2::Pbkdf2 as RingPbkdf2;
+/// PBKDF2 implementation from *ring*
+pub use self::ring_pbkdf2::Pbkdf2;
 
-/// Native Rust implementation of scrypt.
 mod ring_pbkdf2 {
     use primitives::{Primitive, PrimitiveImpl};
     use sod::Sod;
@@ -83,112 +81,6 @@ mod ring_pbkdf2 {
     }
 }
 
-
-/// Native Rust implementation of scrypt.
-mod fastpbkdf2 {
-    extern crate fastpbkdf2;
-    use self::fastpbkdf2::*;
-
-    use primitives::{Primitive, PrimitiveImpl};
-    use sod::Sod;
-
-    use ring::digest;
-    use serde_mcf::Hashes;
-
-    use std::fmt;
-    use std::sync::Arc;
-
-    use super::super::hash_to_id;
-
-    /// Struct holding `PBKDF2` parameters.
-    ///
-    /// This implementation is backed by `fastpbkdf2`.
-    pub struct Pbkdf2 {
-        iterations: u32,
-        algorithm: fn(&[u8], &[u8], u32, &mut [u8]),
-        alg_id: &'static str,
-    }
-
-    lazy_static! {
-        static ref DEFAULT: Arc<Box<PrimitiveImpl>> = {
-            Arc::new(Box::new(Pbkdf2::new_impl(10_000, &digest::SHA256)))
-        };
-    }
-
-    impl Pbkdf2 {
-        /// Create a new PBKDF2 instance using defaults.
-        pub fn default() -> Primitive {
-            Primitive(Sod::Dynamic(Arc::clone(&DEFAULT)))
-        }
-
-        /// Create  a new PBKDF2 instance.
-        pub fn new(iterations: u32, algorithm: &'static digest::Algorithm) -> Primitive {
-            Self::new_impl(iterations, algorithm).into()
-        }
-
-        fn new_impl(iterations: u32, algorithm: &'static digest::Algorithm) -> Self {
-            match hash_to_id(algorithm).as_ref() {
-                "SHA1" => {
-                    Self {
-                        iterations: iterations,
-                        algorithm: pbkdf2_hmac_sha1,
-                        alg_id: "SHA1",
-                    }
-                }
-                "SHA256" => {
-                    Self {
-                        iterations: iterations,
-                        algorithm: pbkdf2_hmac_sha256,
-                        alg_id: "SHA256",
-                    }
-                }
-                "SHA512" => {
-                    Self {
-                        iterations: iterations,
-                        algorithm: pbkdf2_hmac_sha512,
-                        alg_id: "SHA512",
-                    }
-                }
-                _ => panic!("unexpected digest algorithm"),
-            }
-        }
-    }
-
-    impl ::primitives::PrimitiveImpl for Pbkdf2 {
-        /// Compute the scrypt hash
-        fn compute<'a>(&'a self, password: &[u8], salt: &[u8]) -> Vec<u8> {
-            let mut hash = vec![0_u8; 32];
-            (self.algorithm)(password, salt, self.iterations, &mut hash);
-            hash
-        }
-
-        /// Convert parameters into a vector of (key, value) tuples
-        /// for serializing.
-        fn params_as_vec(&self) -> Vec<(&'static str, String)> {
-            vec![("n", self.iterations.to_string())]
-        }
-
-        fn hash_id(&self) -> Hashes {
-            match self.alg_id {
-                "SHA1" => Hashes::Pbkdf2Sha1,
-                "SHA256" => Hashes::Pbkdf2Sha256,
-                "SHA512" => Hashes::Pbkdf2Sha512,
-                _ => panic!("unexpected digest algorithm"),
-            }
-        }
-    }
-
-    impl fmt::Debug for Pbkdf2 {
-        fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-            write!(f,
-                   "PBKDF2-{:?}, iterations: {}",
-                   self.alg_id,
-                   self.iterations)
-        }
-    }
-}
-
-
 #[cfg(test)]
 mod test {
     use ::hashing::*;
@@ -199,23 +91,6 @@ mod test {
     fn sanity_check() {
         let password = "hunter2";
         let params = super::Pbkdf2::default();
-        println!("{:?}", params);
-        let salt = ::get_salt();
-        let hash = params.compute(password.as_bytes(), &salt);
-        let hash2 = params.compute(password.as_bytes(), &salt);
-        assert_eq!(hash, hash2);
-        let out = Output {
-            alg: Algorithm::Single(params.into()),
-            salt: salt,
-            hash: hash,
-        };
-        println!("{:?}", serde_mcf::to_string(&out).unwrap());
-    }
-
-    #[test]
-    fn sanity_check_ring() {
-        let password = "hunter2";
-        let params = super::RingPbkdf2::default();
         println!("{:?}", params);
         let salt = ::get_salt();
         let hash = params.compute(password.as_bytes(), &salt);
@@ -246,27 +121,12 @@ mod test {
 
         let params = Algorithm::Single(super::Pbkdf2::new(1_000, &digest::SHA512));
         primitive_round_trip!(params);
-
-        let params = Algorithm::Single(super::RingPbkdf2::new(1_000, &digest::SHA1));
-        primitive_round_trip!(params);
-
-        let params = Algorithm::Single(super::RingPbkdf2::new(1_000, &digest::SHA256));
-        primitive_round_trip!(params);
-
-        let params = Algorithm::Single(super::RingPbkdf2::new(1_000, &digest::SHA512));
-        primitive_round_trip!(params);
-
     }
 }
 
-#[cfg(features = "bench")]
+#[cfg(feature="bench")]
 mod ring_bench {
-    use super::*;
-    benches!(RingPbkdf2);
-}
-
-#[cfg(features = "bench")]
-mod fast_bench {
+    #[allow(unused_imports)]
     use super::*;
     benches!(Pbkdf2);
 }

--- a/tests/test_ringpbkdf2.rs
+++ b/tests/test_ringpbkdf2.rs
@@ -1,8 +1,0 @@
-extern crate libpasta;
-
-#[macro_use]
-mod common;
-
-use libpasta::primitives::RingPbkdf2;
-
-config_test!(RingPbkdf2, "$$pbkdf2");


### PR DESCRIPTION
With this PR, osx builds are properly supported/tested through Travis.
As part of this, we are removing the fastpbdf2 dependency (which relies on openssl).